### PR TITLE
Count contributors by GitHub login

### DIFF
--- a/github-repo-committers.py
+++ b/github-repo-committers.py
@@ -90,9 +90,16 @@ def repo_details(repo_name):
             earliest_commit = commit_date - timedelta(days_back)
 
         if commit_date > earliest_commit:
-            if commit.raw_data['commit']['committer']['email'] not in repo_authors:
-                repo_authors[commit.raw_data['commit']['committer']['email']] = commit.raw_data['commit']['committer'][
-                    'date']
+            if commit.raw_data['author'] and 'login' in commit.raw_data['author']:
+                author = commit.raw_data['author']['login']
+            else:
+                author = commit.raw_data['commit']['committer']['email']
+            # author = commit.raw_data['commit']['committer']['email']
+
+            if not author.startswith('root@') and author not in repo_authors:
+                    repo_authors[author] = commit.raw_data['commit']['committer']['date']
+            #if commit.raw_data['commit']['committer']['email'] not in repo_authors:
+            #    repo_authors[commit.raw_data['commit']['committer']['email']] = commit.raw_data['commit']['committer']['date']
         else:
             break
 
@@ -100,7 +107,7 @@ def repo_details(repo_name):
         f'In the repository \'{repo_name}\', there are {len(repo_authors)}'
         f' contributor(s) over 90 days with the earliest commit'
         f' on {earliest_commit}.')
-    print('Here is the list of contributors email addresses:')
+    print('Here is the list of Github contributors:')
     for author, commit_date in repo_authors.items():
         print(author + ': ' + commit_date)
     print('\n')
@@ -121,7 +128,7 @@ def org_iterator(org_name):
             authors.update(repo_details(repo.full_name))
         else:
             break
-    print("In total you have " + str(len(authors)) + " contributors over the last 90 day in " + str(max_repos)
+    print("In total you have " + str(len(authors)) + " contributors over the last 90 day in " + str(i)
           + " repositories.")
 
 

--- a/local-repo-committers.py
+++ b/local-repo-committers.py
@@ -3,6 +3,7 @@ import os
 import git.exc
 from git import Repo
 import argparse
+import re
 from datetime import timedelta
 
 
@@ -26,8 +27,12 @@ def read_repo_committers(repo_obj):
                 earliest_commit = commit.committed_datetime - timedelta(days_back)
 
             if commit.committed_datetime > earliest_commit:
-                if commit.committer.email not in repo_authors:
-                    repo_authors[commit.committer.email] = commit.committed_datetime.strftime("%Y-%m-%dT%H:%M:%S")
+                author = commit.committer.email
+                # skip automation users that look like root@1976d98b6ec0
+                if re.match(r"^root@\w+$", author):
+                    continue
+                if author not in repo_authors:
+                    repo_authors[author] = commit.committed_datetime.strftime("%Y-%m-%dT%H:%M:%S")
             else:
                 break
 
@@ -35,7 +40,7 @@ def read_repo_committers(repo_obj):
             f'In the repository \'{repo_obj.working_dir}\', there are {len(repo_authors)}'
             f' contributor(s) over 90 days with the earliest commit'
             f' on {earliest_commit}.')
-        print('Here is the list of contributors email addresses:')
+        print('Here is the list of GitHub contributors:')
         for author, commit_date in repo_authors.items():
             print(author + ': ' + commit_date)
         print('\n')


### PR DESCRIPTION
When counting contributors to a Github repo, we're currently using the committer email address. That is dependent on whatever the end user enters in their Git client. When we can, using the GitHub login associated with the author should be more accurate, since it reflects the author who made the change, and in some cases the committer is an automated process. Unfortunately we can't always get the Github username of the author, so when we can't, we should fall back to committer email.

Other changes:
* I fixed a bug in how we're reporting the number of repositories scanned.
* I also added a `--count_by_email` flag to the `github-repo-committers.py` file to count by committer email, since that is how the script used to work and how the `local-repo-committers.py` script works, and how HawkScan counts contributors.
* Filtering out `root@<commit-hash>` email addresses, as those are automation commits and shouldn't be counted as contributors.