### PR TITLE
Add commit url output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ committers at the end.
 ```console
 usage: github-repo-committers.py [-h] --access_token ACCESS_TOKEN [--org_name ORG_NAME]
                                  [--max_repos MAX_REPOS] [--repo_name REPO_NAME]
+                                 [--commit_urls | --no-commit_urls]
                                  [--ghe_hostname GHE_HOSTNAME] [--count-by {login,name,email}]
 
 Count developers on a GitHub repo or in a GitHub Organization for the last 90 days
@@ -110,6 +111,8 @@ optional arguments:
                         How many repos in the Org do you want to inspect? Default=100
   --repo_name REPO_NAME
                         Name of the repo you want to check in 'org/repo' format
+  --commit_urls, --no-commit_urls
+                        Controls outputting commit URLs, defaults to '--no-commit-urls'                        
   --ghe_hostname GHE_HOSTNAME
                         If you use GHE, this is the hostname part of the URL
   --count-by {username,name,email}


### PR DESCRIPTION
Adds an optional boolean flag called `--commit-urls` or  `--no-commit-urls` for outputting commit URLs for easier commit validation, which defaults to off to keep backwards compatibility.

Without the new flag, it's the same output as before this change:
```shell
topher> pipenv run python3 github-repo-committers.py --access_token $ACCESS_TOKEN --repo_name "kaakaww/contributors_tool"                                                                         <region:us-west-2>
In the repository 'kaakaww/contributors_tool', there are 4 contributor(s) over 90 days with the earliest commit on 2021-08-04 01:05:47.
Here is the list of Github contributors:
sgerlach: 2021-11-02T01:05:47Z
jeremygoldsmith: 2021-10-31T04:07:22Z
azconger: 2023-03-22T23:23:11Z
clamey: 2024-09-09T17:31:05Z
```

With the new flag, we get a URL for each commit:
```shell
topher> pipenv run python3 github-repo-committers.py --access_token $ACCESS_TOKEN --repo_name "kaakaww/contributors_tool" --commit_urls                                                             <region:us-west-2>
In the repository 'kaakaww/contributors_tool', there are 4 contributor(s) over 90 days with the earliest commit on 2021-08-04 01:05:47.
Here is the list of Github contributors:
sgerlach: 2021-11-02T01:05:47Z, https://github.com/kaakaww/contributors_tool/commit/66eee5bb5b32d93562ccf6891a24bf747c621a10
jeremygoldsmith: 2021-10-31T04:07:22Z, https://github.com/kaakaww/contributors_tool/commit/48fa39f9b056cff16c7e3cb39bf598ce3914fc79
azconger: 2023-03-22T23:23:11Z, https://github.com/kaakaww/contributors_tool/commit/c9e8b1a7c52705075d35654a863ae96418f11ea0
clamey: 2024-09-09T17:31:05Z, https://github.com/kaakaww/contributors_tool/commit/cb667e6422ea0acea2dcfa15c4550adf85856793
```